### PR TITLE
Separating core extensions to make them optional

### DIFF
--- a/lib/word_wrap.rb
+++ b/lib/word_wrap.rb
@@ -12,21 +12,3 @@ module WordWrap
     fit ? w.fit : w.wrap
   end
 end
-
-class String
-  def wrap(width=WordWrap::DEFAULT_WIDTH)
-    WordWrap.ww(self, width, false)
-  end
-
-  def wrap!(width=WordWrap::DEFAULT_WIDTH)
-    replace wrap(width)
-  end
-
-  def fit(width=WordWrap::DEFAULT_WIDTH)
-    WordWrap.ww(self, width, true)
-  end
-
-  def fit!(width=WordWrap::DEFAULT_WIDTH)
-    replace fit(width)
-  end
-end

--- a/lib/word_wrap/core_ext.rb
+++ b/lib/word_wrap/core_ext.rb
@@ -1,0 +1,26 @@
+#
+# core_ext.rb
+#
+# Copyright (c) 2015  Radek Pazdera
+# Distributed under the MIT License
+#
+# Optional core exensions, adding the fit and wrap methods to the String class
+#
+
+class String
+  def wrap(width=WordWrap::DEFAULT_WIDTH)
+    WordWrap.ww(self, width, false)
+  end
+
+  def wrap!(width=WordWrap::DEFAULT_WIDTH)
+    replace wrap(width)
+  end
+
+  def fit(width=WordWrap::DEFAULT_WIDTH)
+    WordWrap.ww(self, width, true)
+  end
+
+  def fit!(width=WordWrap::DEFAULT_WIDTH)
+    replace fit(width)
+  end
+end

--- a/lib/word_wrap/version.rb
+++ b/lib/word_wrap/version.rb
@@ -1,3 +1,3 @@
 module WordWrap
-  VERSION = "0.2.2"
+  VERSION = "1.0.0"
 end

--- a/lib/word_wrap/wrapper.rb
+++ b/lib/word_wrap/wrapper.rb
@@ -1,10 +1,12 @@
-# Copyright (c) 2014 Radek Pazdera
+#
+# wrapper.rb
+#
+# Copyright (c) 2014, 2015  Radek Pazdera
 # Distributed under the MIT License
-
-# The actual implementation of wrapping
-# TODO: share code between wrap and fit implementations
+#
 
 module WordWrap
+  # TODO: Refactor similar passages out of the two functions into a common one
   class Wrapper
     def initialize(text, width)
       @text = text
@@ -14,7 +16,6 @@ module WordWrap
     def fit
       lines = []
       next_line = ""
-      continued = false
       @text.lines do |line|
         line.chomp! "\n"
         if line.length == 0

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -1,0 +1,49 @@
+# Copyright (c) 2015  Radek Pazdera
+# Distributed under the MIT License
+
+# Tests for the extensions of the String class
+
+require 'word_wrap/core_ext'
+
+describe WordWrap do
+  describe "core extensions" do
+    it "fit as a part of String interface" do
+      text =<<EOF
+Try-hard 3 wolf moon vinyl.
+
+Mumblecore letterpress iPhone.
+EOF
+
+      expected =<<EOF
+Try-hard 3 wolf moon
+vinyl.
+
+Mumblecore
+letterpress iPhone.
+EOF
+      expect(text.fit(20)).to eql expected
+    end
+
+    it "wraps in-place" do
+      text = "0123456789 01234 0123456"
+      expected =<<EOF
+0123456789
+01234
+0123456
+EOF
+      text.wrap! 10
+      expect(text).to eql expected
+    end
+
+    it "fits in-place" do
+      text = "0123456789 01234 0123456"
+      expected =<<EOF
+0123456789
+01234
+0123456
+EOF
+      text.fit! 10
+      expect(text).to eql expected
+    end
+  end
+end

--- a/spec/ww_spec.rb
+++ b/spec/ww_spec.rb
@@ -1,10 +1,9 @@
-# Copyright (c) 2014 Radek Pazdera
+# Copyright (c) 2014, 2015  Radek Pazdera
 # Distributed under the MIT License
 
-# Several tests for the ww function
+# Tests for the ww function
 
 require 'word_wrap'
-require 'word_wrap/core_ext'
 
 describe WordWrap do
   describe "#ww" do
@@ -251,45 +250,6 @@ extremelylonganduglyword
 EOF
       wrapped = WordWrap.ww(text, 20, true)
       expect(wrapped).to eql expected
-    end
-
-    it "fit as a part of String interface" do
-      text =<<EOF
-Try-hard 3 wolf moon vinyl.
-
-Mumblecore letterpress iPhone.
-EOF
-
-      expected =<<EOF
-Try-hard 3 wolf moon
-vinyl.
-
-Mumblecore
-letterpress iPhone.
-EOF
-      expect(text.fit(20)).to eql expected
-    end
-
-    it "wraps in-place" do
-      text = "0123456789 01234 0123456"
-      expected =<<EOF
-0123456789
-01234
-0123456
-EOF
-      text.wrap! 10
-      expect(text).to eql expected
-    end
-
-    it "fits in-place" do
-      text = "0123456789 01234 0123456"
-      expected =<<EOF
-0123456789
-01234
-0123456
-EOF
-      text.fit! 10
-      expect(text).to eql expected
     end
   end
 end

--- a/spec/ww_spec.rb
+++ b/spec/ww_spec.rb
@@ -3,7 +3,8 @@
 
 # Several tests for the ww function
 
-require "word_wrap"
+require 'word_wrap'
+require 'word_wrap/core_ext'
 
 describe WordWrap do
   describe "#ww" do
@@ -15,7 +16,7 @@ describe WordWrap do
 0123456
 EOF
       wrapped = WordWrap.ww(text, 10)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "works without breaks" do
@@ -31,7 +32,7 @@ EOF
 0123456
 EOF
       wrapped = WordWrap.ww(text, 10)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "wraps two paragraphs" do
@@ -59,7 +60,7 @@ distillery cray
 semiotics.
 EOF
       wrapped = WordWrap.ww(text, 20)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "wraps a partialy wrapped paragraph" do
@@ -84,7 +85,7 @@ out pop-up direct
 trade.
 EOF
       wrapped = WordWrap.ww(text, 20)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "wrapping keeps whitespace" do
@@ -121,7 +122,7 @@ extremelylonganduglyword
 
 EOF
       wrapped = WordWrap.ww(text, 20)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "wrap as a part of String interface" do
@@ -138,7 +139,7 @@ moon vinyl.
 Mumblecore
 letterpress iPhone.
 EOF
-      text.wrap(20).should eql expected
+      expect(text.wrap(20)).to eql expected
     end
 
     it "fits a single line correctly" do
@@ -149,7 +150,7 @@ EOF
 0123456
 EOF
       wrapped = WordWrap.ww(text, 10, true)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "works without breaks" do
@@ -164,7 +165,7 @@ EOF
 0123456
 EOF
       wrapped = WordWrap.ww(text, 10, true)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "fits two paragraphs" do
@@ -191,7 +192,7 @@ distillery cray
 semiotics.
 EOF
       wrapped = WordWrap.ww(text, 20, true)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "fits a partialy wrapped paragraph" do
@@ -214,7 +215,7 @@ they sold out pop-up
 direct trade.
 EOF
       wrapped = WordWrap.ww(text, 20, true)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "fitting keeps empty lines" do
@@ -249,7 +250,7 @@ extremelylonganduglyword
 
 EOF
       wrapped = WordWrap.ww(text, 20, true)
-      wrapped.should eql expected
+      expect(wrapped).to eql expected
     end
 
     it "fit as a part of String interface" do
@@ -266,7 +267,7 @@ vinyl.
 Mumblecore
 letterpress iPhone.
 EOF
-      text.fit(20).should eql expected
+      expect(text.fit(20)).to eql expected
     end
 
     it "wraps in-place" do
@@ -277,7 +278,7 @@ EOF
 0123456
 EOF
       text.wrap! 10
-      text.should eql expected
+      expect(text).to eql expected
     end
 
     it "fits in-place" do
@@ -288,7 +289,7 @@ EOF
 0123456
 EOF
       text.fit! 10
-      text.should eql expected
+      expect(text).to eql expected
     end
   end
 end


### PR DESCRIPTION
This change breaks the API.

Related to #6 
